### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# DEPRESSED-JAS 
+- Version: 2.5
+- Language: en-US
+- Timezone Offset: +08:00
+- User Agent: Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.36
+
+What steps will reproduce the problem?
+1. 
+2. 
+3. 
+
+What is the expected result?
+
+
+What happens instead?
+
+
+Screenshot URL:
+
+
+Logs:
+
+[2016-01-26T19:15:52.708Z] Creating bug report.
+[2016-01-26T19:17:42.818Z] options.loadCalendarList()
+[2016-01-26T19:17:45.598Z] Creating bug report.


### PR DESCRIPTION
- Version: 2.5
- Language: en-US
- Timezone Offset: +08:00
- User Agent: Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.36

What steps will reproduce the problem?
1. 
2. 
3. 

What is the expected result?

What happens instead?

Screenshot URL:

Logs:

[2016-01-26T19:15:52.708Z] Creating bug report.
[2016-01-26T19:17:42.818Z] options.loadCalendarList()
[2016-01-26T19:17:45.598Z] Creating bug report.
